### PR TITLE
Add ending string after having closed all unclosed html-tags

### DIFF
--- a/src/Truncate.php
+++ b/src/Truncate.php
@@ -141,9 +141,6 @@ class Truncate extends Twig_Extension
             }
         }
 
-        // add the defined ending to the text
-        $truncate .= $ending;
-
         if ($considerHtml) {
 
             // close all unclosed html-tags
@@ -151,6 +148,9 @@ class Truncate extends Twig_Extension
                 $truncate .= '</' . $tag . '>';
             }
         }
+
+        // add the defined ending to the text
+        $truncate .= $ending;
 
         return $truncate;
     }


### PR DESCRIPTION
This avoid to have the ending part formatted by the html tags.
